### PR TITLE
Feature: Pass a component into Leaflet map popup

### DIFF
--- a/app/scripts/containers/asInfiniteListCalendar.js
+++ b/app/scripts/containers/asInfiniteListCalendar.js
@@ -16,6 +16,7 @@ export default function asInfiniteListCalendar(WrappedListItemComponent) {
       listItems: PropTypes.array,
       onClick: PropTypes.func,
       onEditClick: PropTypes.func,
+      placeIdFilter: PropTypes.number,
       resourceName: PropTypes.string.isRequired,
       totalPageCount: PropTypes.number,
     }
@@ -26,6 +27,7 @@ export default function asInfiniteListCalendar(WrappedListItemComponent) {
       listItems: [],
       onClick: undefined,
       onEditClick: undefined,
+      placeIdFilter: undefined,
       totalPageCount: undefined,
     }
 
@@ -63,6 +65,7 @@ export default function asInfiniteListCalendar(WrappedListItemComponent) {
           item={item}
           onClick={this.props.onClick}
           onEditClick={this.props.onEditClick}
+          placeIdFilter={this.props.placeIdFilter}
         />
       )
     }
@@ -87,7 +90,7 @@ export default function asInfiniteListCalendar(WrappedListItemComponent) {
     }
 
     renderListItems() {
-      const { listItems } = this.props
+      const { listItems, placeIdFilter } = this.props
 
       if (!this.props.isLoading && listItems.length === 0) {
         return (
@@ -98,6 +101,13 @@ export default function asInfiniteListCalendar(WrappedListItemComponent) {
       }
 
       return listItems.map((item, index) => {
+        console.log(item)
+        if ( placeIdFilter !== undefined ) {
+          if( placeIdFilter !== item.placeId ) {
+            return null
+          }
+        }
+
         const previousItem = index > 0 ? listItems[index - 1] : null
 
         const dateA = DateTime.fromISO(item.slots[0].from)
@@ -159,6 +169,7 @@ export default function asInfiniteListCalendar(WrappedListItemComponent) {
   function mapStateToProps(state, props) {
     return {
       ...state.infiniteList[props.resourceName],
+      ...state.infiniteList[props.placeIdFilter],
     }
   }
 

--- a/app/scripts/views/PlacesShow.js
+++ b/app/scripts/views/PlacesShow.js
@@ -2,8 +2,9 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { push } from 'connected-react-router'
 
-import { asInfiniteList } from '../containers'
+import { asInfiniteListCalendar } from '../containers'
 import { CuratedEventListItem } from '../components'
 import { LocationMap, ImageGallery, AnimalLink } from '../components'
 import { cachedResource } from '../services/resources'
@@ -11,19 +12,32 @@ import { fetchResource } from '../actions/resources'
 import { numberToSlotSizeStrHuman } from '../../../common/utils/slots'
 import { translate } from '../../../common/services/i18n'
 
-const WrappedInfiniteList = asInfiniteList(CuratedEventListItem)
+const WrappedInfiniteList = asInfiniteListCalendar(CuratedEventListItem)
 
 class PlacesShow extends Component {
   static propTypes = {
     fetchResource: PropTypes.func.isRequired,
     isError: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,
+    push: PropTypes.func.isRequired,
     resourceData: PropTypes.object.isRequired,
     resourceSlug: PropTypes.string.isRequired,
   }
 
   componentWillMount() {
     this.props.fetchResource('places', this.props.resourceSlug)
+  }
+
+  onClick(item) {
+    this.props.push(`/events/${item.slug}`)
+  }
+
+  onEditClick(item) {
+    this.props.push(`/events/${item.slug}/edit`)
+  }
+
+  onPreviewClick() {
+    this.props.push('/tickets')
   }
 
   renderActionButton() {
@@ -151,7 +165,10 @@ class PlacesShow extends Component {
   renderEventList() {
     return (
       <WrappedInfiniteList
+        placeIdFilter={this.props.resourceData.id}
         resourceName="events"
+        onClick={this.onClick}
+        onEditClick={this.onEditClick}
       />
     )
   }
@@ -206,6 +223,9 @@ class PlacesShow extends Component {
 
   constructor(props) {
     super(props)
+
+    this.onClick = this.onClick.bind(this)
+    this.onEditClick = this.onEditClick.bind(this)
   }
 }
 
@@ -225,5 +245,6 @@ function mapStateToProps(state, ownProps) {
 export default connect(
   mapStateToProps, {
     fetchResource,
+    push,
   }
 )(PlacesShow)


### PR DESCRIPTION
It would be very neat if the event info that appears in the map popup could be a react component (the CalendarList) but I'm having trouble making it work. Tried as described here: https://stackoverflow.com/questions/58181405/pass-a-react-component-to-leaflet-popup it is working just by passing the event info as html, but if there is a smart fix for this that I don't know about......