### PR TITLE
Feature: Venue slots disabled by default

### DIFF
--- a/app/scripts/forms/PlaceForm.js
+++ b/app/scripts/forms/PlaceForm.js
@@ -65,12 +65,14 @@ class PlaceForm extends Component {
     handleSubmit: PropTypes.func.isRequired,
     isLoading: PropTypes.bool,
     isSlotSizeVisible: PropTypes.bool,
+    onDisableSlotsChange: PropTypes.func,
   }
 
   static defaultProps = {
     errorMessage: undefined,
     isLoading: false,
     isSlotSizeVisible: true,
+    onDisableSlotsChange: undefined,
   }
 
   renderErrorMessage() {
@@ -142,6 +144,15 @@ class PlaceForm extends Component {
         <hr />
 
         <h2>{ translate('forms.place.slots') }</h2>
+
+        <Field
+          component={FormCheckbox}
+          disabled={this.props.isLoading}
+          inline={true}
+          label={translate('forms.place.areSlotsDisabled')}
+          name="areSlotsDisabled"
+          onChange={this.props.onDisableSlotsChange}
+        />
 
         <Field
           component={FormSlotSizeEditor}

--- a/app/scripts/views/PlacesNew.js
+++ b/app/scripts/views/PlacesNew.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { PlaceForm } from '../forms'
 import { cachedResource } from '../services/resources'
 import { createResource } from '../actions/resources'
-import { getDisabledSlotIndexes, generateNewSlotItems, generateNewDisabledSlotItems } from '../../../common/utils/slots'
+import { getDisabledSlotIndexes, generateNewDisabledSlotItems } from '../../../common/utils/slots'
 import { translate } from '../../../common/services/i18n'
 import { withConfig } from '../containers'
 
@@ -55,7 +55,7 @@ class PlacesNew extends Component {
     const { festivalDateStart, festivalDateEnd } = config
 
     const slots = generateNewDisabledSlotItems(
-      DEFAULT_SLOT_SIZE, null, festivalDateStart, festivalDateEnd
+      DEFAULT_SLOT_SIZE, festivalDateStart, festivalDateEnd
     )
 
     const initialValues = {

--- a/app/scripts/views/PlacesNew.js
+++ b/app/scripts/views/PlacesNew.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { PlaceForm } from '../forms'
 import { cachedResource } from '../services/resources'
 import { createResource } from '../actions/resources'
-import { getDisabledSlotIndexes, generateNewSlotItems } from '../../../common/utils/slots'
+import { getDisabledSlotIndexes, generateNewSlotItems, generateNewDisabledSlotItems } from '../../../common/utils/slots'
 import { translate } from '../../../common/services/i18n'
 import { withConfig } from '../containers'
 
@@ -54,7 +54,7 @@ class PlacesNew extends Component {
     const { config } = this.props
     const { festivalDateStart, festivalDateEnd } = config
 
-    const slots = generateNewSlotItems(
+    const slots = generateNewDisabledSlotItems(
       DEFAULT_SLOT_SIZE, null, festivalDateStart, festivalDateEnd
     )
 

--- a/app/scripts/views/PlacesNew.js
+++ b/app/scripts/views/PlacesNew.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { PlaceForm } from '../forms'
 import { cachedResource } from '../services/resources'
 import { createResource } from '../actions/resources'
-import { getDisabledSlotIndexes, generateNewDisabledSlotItems } from '../../../common/utils/slots'
+import { getDisabledSlotIndexes, generateNewDisabledSlotItems, generateNewSlotItems } from '../../../common/utils/slots'
 import { translate } from '../../../common/services/i18n'
 import { withConfig } from '../containers'
 
@@ -20,6 +20,45 @@ class PlacesNew extends Component {
     errorMessage: PropTypes.string.isRequired,
     isLoading: PropTypes.bool.isRequired,
     nextRandomId: PropTypes.string.isRequired,
+  }
+
+  componentWillMount() {
+    const { config } = this.props
+    const { festivalDateStart, festivalDateEnd } = config
+
+    const slots = generateNewSlotItems(DEFAULT_SLOT_SIZE, [], festivalDateStart, festivalDateEnd)
+
+    this.setState({
+      generatedSlots: {
+        slots: slots,
+        disableSlots: false,
+      },
+    })
+  }
+
+  onDisableSlotsChange(event) {
+    const { config } = this.props
+    const { festivalDateStart, festivalDateEnd } = config
+    let slots = null
+    let disableSlots = false
+
+    if (event) {
+      slots = generateNewDisabledSlotItems(
+        DEFAULT_SLOT_SIZE, festivalDateStart, festivalDateEnd
+      )
+      disableSlots = true
+    } else {
+      slots = generateNewSlotItems(
+        DEFAULT_SLOT_SIZE, [], festivalDateStart, festivalDateEnd
+      )
+      disableSlots = false
+    }
+    this.setState({
+      generatedSlots: {
+        slots: slots,
+        disableSlots: disableSlots,
+      },
+    })
   }
 
   onSubmit(values) {
@@ -52,11 +91,6 @@ class PlacesNew extends Component {
 
   render() {
     const { config } = this.props
-    const { festivalDateStart, festivalDateEnd } = config
-
-    const slots = generateNewDisabledSlotItems(
-      DEFAULT_SLOT_SIZE, festivalDateStart, festivalDateEnd
-    )
 
     const initialValues = {
       isPublic: true,
@@ -71,8 +105,9 @@ class PlacesNew extends Component {
       },
       slots: {
         slotSize: DEFAULT_SLOT_SIZE,
-        slots,
+        slots: this.state.generatedSlots.slots,
       },
+      areSlotsDisabled: this.state.generatedSlots.disableSlots,
     }
 
     return (
@@ -89,6 +124,7 @@ class PlacesNew extends Component {
           errorMessage={this.props.errorMessage}
           initialValues={initialValues}
           isLoading={this.props.isLoading}
+          onDisableSlotsChange={this.onDisableSlotsChange}
           onSubmit={this.onSubmit}
         />
       </section>
@@ -99,6 +135,7 @@ class PlacesNew extends Component {
     super(props)
 
     this.onSubmit = this.onSubmit.bind(this)
+    this.onDisableSlotsChange = this.onDisableSlotsChange.bind(this)
   }
 }
 

--- a/common/locales/forms.en.js
+++ b/common/locales/forms.en.js
@@ -126,6 +126,7 @@ export default {
       titleRequired: 'Please give your place a title',
     },
     areEventsPublic: 'Events in this place are visible in the calendar',
+    areSlotsDisabled: 'Disable all slots at this place by default',
     description: 'Describe your place',
     publicOrPrivate: 'Is it public or private?',
     slots: 'When is it bookable?',

--- a/common/utils/slots.js
+++ b/common/utils/slots.js
@@ -120,6 +120,35 @@ export function generateNewSlotItems(slotSize, existingSlots = [], festivalDateS
 
   return slotItems
 }
+export function generateNewDisabledSlotItems(slotSize, existingSlots = [], festivalDateStart, festivalDateEnd) {
+  const slotItems = []
+
+  if (!checkSlotSize(slotSize).isValid) {
+    return slotItems
+  }
+
+  let slotIndex = 0
+  let from = DateTime.fromISO(festivalDateStart, { zone: 'utc' })
+  let to = addSlotDuration(from, slotSize)
+
+  while (isInFestivalRange(to, festivalDateStart, festivalDateEnd)) {
+    slotItems.push({
+      eventId: null,
+      from,
+      fromTimeStr: from.toFormat(TIME_FORMAT),
+      isDisabled: true,
+      slotIndex,
+      to,
+      toTimeStr: to.toFormat(TIME_FORMAT),
+    })
+
+    slotIndex += 1
+    from = addSlotDuration(from, slotSize)
+    to = addSlotDuration(from, slotSize)
+  }
+
+  return slotItems
+}
 
 export function getSlotTimes(slotSize, slotIndex, festivalDateStart) {
   const from = DateTime

--- a/common/utils/slots.js
+++ b/common/utils/slots.js
@@ -120,7 +120,7 @@ export function generateNewSlotItems(slotSize, existingSlots = [], festivalDateS
 
   return slotItems
 }
-export function generateNewDisabledSlotItems(slotSize, existingSlots = [], festivalDateStart, festivalDateEnd) {
+export function generateNewDisabledSlotItems(slotSize, festivalDateStart, festivalDateEnd) {
   const slotItems = []
 
   if (!checkSlotSize(slotSize).isValid) {


### PR DESCRIPTION
I think this is useful for festivals which happen for more than one or two days. AU will be over one week, which would mean many slots would have to be disabled when creating venues. It could be implemented as a tick box in the PlacesNew view which disables all slots.