### PR TITLE
Fix for events not appearing on their start day

### DIFF
--- a/server/controllers/event.js
+++ b/server/controllers/event.js
@@ -484,13 +484,13 @@ export default {
 
       if (req.query.to) {
         slotsFilter.from = {
-          [Op.lt]: req.query.to,
+          [Op.lte]: req.query.to,
         }
       }
 
       if (req.query.from) {
         slotsFilter.to = {
-          [Op.gt]: req.query.from,
+          [Op.gte]: req.query.from,
         }
       }
 

--- a/server/controllers/resource.js
+++ b/server/controllers/resource.js
@@ -74,11 +74,11 @@ function findAllWithAvailability(req, res, next) {
                   eventId,
                 }, {
                   from: {
-                    [Op.lt]: req.query.to,
+                    [Op.lte]: req.query.to,
                   },
                 }, {
                   to: {
-                    [Op.gt]: req.query.from,
+                    [Op.gte]: req.query.from,
                   },
                 }],
               },


### PR DESCRIPTION
This fixes a problem where events ending at midnight don't show up on the correct day.

I don't know if it's a great fix, feels like it's not really getting to the core of the issue, but it means events are seen on the day they start (and end ;-p). 